### PR TITLE
ページ遷移をrouterからLinkに変更

### DIFF
--- a/front/components/atom/header/HeaderMenu.tsx
+++ b/front/components/atom/header/HeaderMenu.tsx
@@ -1,17 +1,31 @@
+//lib
+import Link from 'next/link'
+
 interface Props {
-  clickEvent: () => void
+  clickEvent?: () => void
+  path?: string
   contentsName: string
   Icon: React.ReactNode
 }
 
-export const HeaderMenu: React.FC<Props> = ({ clickEvent, contentsName, Icon }) => {
+export const HeaderMenu: React.FC<Props> = ({ clickEvent, path, contentsName, Icon }) => {
   return (
     <>
-      <li className="my-1">
-        <p onClick={clickEvent}>
-          {Icon} {contentsName}
-        </p>
-      </li>
+      {path ? (
+        <li className="my-1">
+          <Link href={path}>
+            <a>
+              {Icon} {contentsName}
+            </a>
+          </Link>
+        </li>
+      ) : (
+        <li className="my-1" onClick={clickEvent}>
+          <p>
+            {Icon} {contentsName}
+          </p>
+        </li>
+      )}
     </>
   )
 }

--- a/front/components/molecule/Header.tsx
+++ b/front/components/molecule/Header.tsx
@@ -44,18 +44,14 @@ export const Header: React.FC = () => {
                 tabIndex={0}
                 className="dropdown-content menu rounded-box right-1 top-1 w-60 bg-base-100 p-2 shadow"
               >
+                <HeaderMenu path="/" contentsName={'ホーム'} Icon={<IconHome />} />
                 <HeaderMenu
-                  clickEvent={() => router.push('/')}
-                  contentsName={'ホーム'}
-                  Icon={<IconHome />}
-                />
-                <HeaderMenu
-                  clickEvent={() => router.push(`/updateProf/${session?.user?.id}`)}
+                  path={`/updateProf/${session?.user?.id}`}
                   contentsName={'プロフィール編集'}
                   Icon={<IconUser />}
                 />
                 <HeaderMenu
-                  clickEvent={() => router.push(`/setting/${session?.user?.id}`)}
+                  path={`/setting/${session?.user?.id}`}
                   contentsName={'設定'}
                   Icon={<IconSettings />}
                 />

--- a/front/hooks/mutate/useMutateAuth.ts
+++ b/front/hooks/mutate/useMutateAuth.ts
@@ -74,6 +74,7 @@ export const useMutateAuth = () => {
       .then(() => {
         resetProfile()
         queryClient.removeQueries('profile')
+        toast.success('ログアウトしました')
       })
       .catch((err: any) => {
         throw new Error(err.message)


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要

ページ遷移にuseRouterを使用していたがLinkコンポーネントに変更
ログアウトのみそのままrouterを使用しています。

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

# 変更内容

routerは本来ロジック内での遷移で飛ばす際に使うためただの遷移だとLinkの方が良いため

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

# 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
