### PR TITLE
コンポーネント切り分け

### DIFF
--- a/front/components/DashBoard.tsx
+++ b/front/components/DashBoard.tsx
@@ -12,8 +12,8 @@ import { useQueryProfile } from '../hooks/query/useQueryProfile'
 //components
 import { Admin } from './Admin'
 import { Independent } from './atom/Independent'
+import { InitSetting } from './InitSetting'
 import { Spinner } from './atom/Spinner'
-import { ProfSetting } from './ProfSetting'
 
 //images
 import img from '../images/independent.png'
@@ -43,12 +43,12 @@ export const DashBoard: React.FC = () => {
           )}
         </>
       ) : (
-        <div className="">
+        <div>
           <ErrorBoundary
             fallback={<ExclamationCircleIcon className="my-5 h-10 w-10 text-pink-500" />}
           >
             <Suspense fallback={<Spinner />}>
-              <ProfSetting />
+              <InitSetting />
             </Suspense>
           </ErrorBoundary>
         </div>

--- a/front/components/InitSetting.tsx
+++ b/front/components/InitSetting.tsx
@@ -4,20 +4,20 @@ import { SInput } from './atom/Input'
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 
-//components
-import { RoleImage } from './atom/RoleImage'
-
 //utils
 import useStore from '../store'
 
 //hooks
 import { useMutateProfile } from '../hooks/mutate/useMutateProfile'
 
+//components
+import { RoleImage } from './atom/RoleImage'
+
 //images
 import employee from '../images/employee.png'
 import manager from '../images/manager.png'
 
-export const ProfSetting: React.FC = () => {
+export const InitSetting: React.FC = () => {
   const [active, setActive] = useState(false)
   const router = useRouter()
   const session = useStore((state) => state.session)
@@ -46,7 +46,7 @@ export const ProfSetting: React.FC = () => {
   }
 
   return (
-    <div className="mx-3">
+    <div>
       <div className="my-10 text-center font-sans text-4xl tracking-widest text-gray-500">
         ようこそ
       </div>

--- a/front/components/atom/Avatar.tsx
+++ b/front/components/atom/Avatar.tsx
@@ -1,0 +1,14 @@
+//lib
+import Image, { StaticImageData } from 'next/image'
+
+interface Props {
+  img: StaticImageData
+}
+
+export const Avatar: React.FC<Props> = ({ img }) => {
+  return (
+    <div className="my-10 text-center hover:cursor-pointer hover:opacity-60">
+      <Image src={img} width={300} height={300} className="rounded-full" />
+    </div>
+  )
+}

--- a/front/components/atom/Notice.tsx
+++ b/front/components/atom/Notice.tsx
@@ -7,7 +7,7 @@ interface Props {
   autoClose?: number
 }
 
-export const Notice: React.FC<Props> = ({ position = 'top-center', autoClose = 4000 }) => {
+export const Notice: React.FC<Props> = ({ position = 'top-center', autoClose = 1000 }) => {
   const contextClass = {
     success: 'bg-blue-600',
     error: 'bg-red-600',

--- a/front/components/atom/UploadButton.tsx
+++ b/front/components/atom/UploadButton.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  changeEvent: (e: any) => void // 仮
+  children: JSX.Element
+}
+
+export const UploadButton: React.FC<Props> = ({ changeEvent, children }) => {
+  return (
+    <div className="flex justify-center">
+      <label htmlFor="avatar">{children}</label>
+      <input className="hidden" type="file" id="avatar" accept="image/*" onChange={changeEvent} />
+    </div>
+  )
+}

--- a/front/components/molecule/RoleSelect.tsx
+++ b/front/components/molecule/RoleSelect.tsx
@@ -1,0 +1,30 @@
+//components
+import { RoleImage } from '../atom/RoleImage'
+
+//images
+import employee from '../../images/employee.png'
+import manager from '../../images/manager.png'
+
+interface Props {
+  selectRole: (bool: boolean) => void
+  active: boolean
+}
+
+export const RoleSelect: React.FC<Props> = ({ selectRole, active }) => {
+  return (
+    <>
+      <p className="my-4 text-gray-500">仕事の種類</p>
+      <p className=" text-sm text-red-400">※ 仕事の種類はあとで変更ができません! ※</p>
+      <div className="mt-4 flex">
+        <RoleImage src={manager} onClick={() => selectRole(true)} role={'管理者'} active={active} />
+        <span className="mx-5" />
+        <RoleImage
+          src={employee}
+          onClick={() => selectRole(false)}
+          role={'従業員'}
+          active={!active}
+        />
+      </div>
+    </>
+  )
+}

--- a/front/hooks/mutate/useMutateProfile.tsx
+++ b/front/hooks/mutate/useMutateProfile.tsx
@@ -1,4 +1,5 @@
 //lib
+import { toast } from 'react-toastify'
 import { useQueryClient, useMutation } from 'react-query'
 
 //utils
@@ -19,15 +20,16 @@ export const useMutateProfile = () => {
     {
       onSuccess: (res) => {
         queryClient.setQueryData('profile', res[0])
+        toast.success('登録完了')
       },
       onError: (err: any) => {
-        alert(err.message)
+        toast.error(err.messages)
       },
     },
   )
 
   const updateProfileMutation = useMutation(
-    async (profile: Omit<Profile, 'updated_at' | 'created_at'>) => {
+    async (profile: Omit<Profile, 'updated_at' | 'created_at' | 'isAdmin'>) => {
       const { data, error } = await supabase.from('profiles').update(profile).eq('id', profile.id)
       if (error) throw new Error(error.message)
       return data
@@ -35,9 +37,10 @@ export const useMutateProfile = () => {
     {
       onSuccess: (res) => {
         queryClient.setQueryData('profile', res[0])
+        toast.success('プロフィールを編集しました')
       },
       onError: (err: any) => {
-        alert(err.messages)
+        toast.error(err.messages)
       },
     },
   )

--- a/front/pages/updateProf/[uid].tsx
+++ b/front/pages/updateProf/[uid].tsx
@@ -3,8 +3,13 @@ import { NextPage } from 'next'
 
 //components
 import { Layout } from '../../components/Layout'
+import { EditProfile } from '../../components/EditProfile'
 
 const ProfileUpdate: NextPage = () => {
-  return <Layout title="プロフィール編集">プロフィール更新ページ</Layout>
+  return (
+    <Layout title="プロフィール編集">
+      <EditProfile />
+    </Layout>
+  )
 }
 export default ProfileUpdate

--- a/front/pages/updateProf/[uid].tsx
+++ b/front/pages/updateProf/[uid].tsx
@@ -3,12 +3,11 @@ import { NextPage } from 'next'
 
 //components
 import { Layout } from '../../components/Layout'
-import { EditProfile } from '../../components/EditProfile'
 
 const ProfileUpdate: NextPage = () => {
   return (
     <Layout title="プロフィール編集">
-      <EditProfile />
+      <div>仮</div>
     </Layout>
   )
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要

一旦コミットします。
致命的なバグを見つけました。後で修正します


<!-- 変更の目的 もしくは 関連する Issue 番号 -->

# 変更内容

役割選択のコンポーネントを切り分け、画像をアップロードするボタンを作成、Avatarを表示するコンポーネントを作成

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

# 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足

プロフ更新ページでリロードするとprofileのデータがnullに設定されます。
そのため初期設定画面が描画されてしまいます。初期設定は一度のみ設定できるので初期設定画面からユーザが抜け出せないバグが発生してます

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
