### PR TITLE
初期設定画面が一瞬描画されるバグ修正

### DIFF
--- a/front/components/DashBoard.tsx
+++ b/front/components/DashBoard.tsx
@@ -3,62 +3,23 @@ import { ErrorBoundary } from 'react-error-boundary'
 import { ExclamationCircleIcon } from '@heroicons/react/solid'
 import { Suspense } from 'react'
 
-//utils
-import useStore from '../store'
-
 //hooks
 import { useQueryProfile } from '../hooks/query/useQueryProfile'
 
 //components
 import { Admin } from './Admin'
-import { Independent } from './atom/Independent'
+import { Employee } from './Employee'
 import { InitSetting } from './InitSetting'
 import { Spinner } from './atom/Spinner'
 
-//images
-import img from '../images/independent.png'
-
 export const DashBoard: React.FC = () => {
-  const session = useStore((state) => state.session)
-
   const { data } = useQueryProfile()
 
   return (
-    <>
-      {data ? (
-        <>
-          {data.isAdmin ? (
-            <>
-              <ErrorBoundary
-                fallback={<ExclamationCircleIcon className="my-5 h-10 w-10 text-pink-500" />}
-              >
-                <Suspense fallback={<Spinner />}>
-                  <Admin />
-                </Suspense>
-              </ErrorBoundary>
-            </>
-          ) : (
-            <div>
-              {/* <Employee とか作ってその中で所属の有無で分岐> */}
-              <Independent
-                heading="参加しているグループが見つかりません"
-                tips="管理者からグループに招待してもらいましょう！"
-                img={img}
-              />
-            </div>
-          )}
-        </>
-      ) : (
-        <div>
-          <ErrorBoundary
-            fallback={<ExclamationCircleIcon className="my-5 h-10 w-10 text-pink-500" />}
-          >
-            <Suspense fallback={<Spinner />}>
-              <InitSetting />
-            </Suspense>
-          </ErrorBoundary>
-        </div>
-      )}
-    </>
+    <ErrorBoundary fallback={<ExclamationCircleIcon className="my-5 h-10 w-10 text-pink-500" />}>
+      <Suspense fallback={<Spinner />}>
+        <>{data ? <>{data.isAdmin ? <Admin /> : <Employee />}</> : <InitSetting />}</>
+      </Suspense>
+    </ErrorBoundary>
   )
 }

--- a/front/components/Employee.tsx
+++ b/front/components/Employee.tsx
@@ -1,0 +1,15 @@
+//components
+import { Independent } from './atom/Independent'
+
+//images
+import img from '../images/independent.png'
+
+export const Employee: React.FC = () => {
+  return (
+    <Independent
+      heading="参加しているグループが見つかりません"
+      tips="管理者からグループに招待してもらいましょう！"
+      img={img}
+    />
+  )
+}

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -13,6 +13,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
+      suspense: true,
       refetchOnWindowFocus: false,
     },
   },

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -8,13 +8,30 @@ import useStore from '../store'
 import { Auth } from '../components/Auth'
 import { Layout } from '../components/Layout'
 import { DashBoard } from '../components/DashBoard'
+import { ExclamationCircleIcon } from '@heroicons/react/solid'
+import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import { Spinner } from '../components/atom/Spinner'
 
 const Home: NextPage = () => {
   const session = useStore((state) => state.session)
 
   const title = session ? 'ホーム' : 'ログイン'
-
-  return <Layout title={title}>{!session ? <Auth /> : <DashBoard />}</Layout>
+  return (
+    <Layout title={title}>
+      {!session ? (
+        <Auth />
+      ) : (
+        <ErrorBoundary
+          fallback={<ExclamationCircleIcon className="my-5 h-10 w-10 text-pink-500" />}
+        >
+          <Suspense fallback={<Spinner />}>
+            <DashBoard />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </Layout>
+  )
 }
 
 export default Home


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要

初期設定が完了しているユーザでもメインぺーじをロードすると初期設定ページが一瞬描画されてしまうバグを修正

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

# 変更内容

一時useQuery の設定でsuspenceをfalseにしていたがtrueに直しました。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

# 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
