### PR TITLE
ユーザ削除の際のバグ修正

### DIFF
--- a/front/hooks/subscribe/useSubscribeOrganization.ts
+++ b/front/hooks/subscribe/useSubscribeOrganization.ts
@@ -12,9 +12,12 @@ import { Organization } from '../../types'
 export const useSubscribeOrganization = () => {
   const queryClient = useQueryClient()
   useEffect(() => {
+    console.log('Effect起動')
     const subsc = supabase
       .from('organizations')
       .on('INSERT', (payload: SupabaseRealtimePayload<Organization>) => {
+        console.log('INSERT invoked')
+        console.log(payload)
         let previousOrganization = queryClient.getQueryData<Organization>('organization')
         if (!previousOrganization) {
           previousOrganization = undefined
@@ -41,6 +44,8 @@ export const useSubscribeOrganization = () => {
         })
       })
       .on('DELETE', () => {
+        console.log('DELETE invoked')
+
         let previousOrganization = queryClient.getQueryData<Organization>('organization')
         if (!previousOrganization) {
           previousOrganization = undefined

--- a/front/pages/setting/[uid].tsx
+++ b/front/pages/setting/[uid].tsx
@@ -18,21 +18,23 @@ const Setting: NextPage = () => {
   const resetOrganization = useStore((state) => state.resetOrganization)
 
   const { logoutMutation, userDeleteMutation } = useMutateAuth()
-  const router = useRouter()
+  const { push } = useRouter()
 
   const signOut = () => {
     if (confirm('ログアウトしますか？')) {
       resetProfile()
       resetOrganization()
       logoutMutation.mutate()
-      router.push('/')
+      push('/')
     } else {
       return
     }
   }
 
   const deleteUser = () => {
-    if (confirm('本当に削除しますか?')) userDeleteMutation.mutateAsync(session?.user?.id)
+    if (confirm('本当に削除しますか?')) {
+      userDeleteMutation.mutateAsync(session?.user?.id).then(() => push('/'))
+    }
   }
 
   return (


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要

ユーザを削除した際にパスをルートに戻すようにしていなかったため、設定ページのパスのまま認証画面に戻ってしまうバグを修正しました。

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

# 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

# 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
