### PR TITLE
メンバー一覧ページ作成

### DIFF
--- a/front/components/atom/MemberList.tsx
+++ b/front/components/atom/MemberList.tsx
@@ -1,0 +1,49 @@
+// lib
+import Image from 'next/image'
+import { useDownloadUrl } from '../../hooks/useDownloadUrl'
+
+//images
+import logo from '../../images/headerLogo.png'
+
+interface Props {
+  key: number
+  username: string
+  avatar: string
+  is_admin: boolean
+}
+
+export const MemberList: React.FC<Props> = ({ key, username, avatar, is_admin }) => {
+  const { fullUrl: avatarUrl } = useDownloadUrl(avatar, 'avatars')
+
+  return (
+    <>
+      <tr key={key}>
+        <td>
+          <div className="flex items-center space-x-3">
+            <div className="avatar">
+              <div className="mask mask-squircle h-12 w-12">
+                <Image
+                  src={avatarUrl ? avatarUrl : logo}
+                  alt="member avatar"
+                  width={48}
+                  height={48}
+                />
+              </div>
+            </div>
+            <div>
+              <div className="font-bold">{username}</div>
+            </div>
+          </div>
+        </td>
+        <td>
+          {is_admin ? '管理者' : '従業員'}
+          <br />
+        </td>
+        <td>
+          招待済み{/* 仮 */}
+          <br />
+        </td>
+      </tr>
+    </>
+  )
+}

--- a/front/components/organisms/AdminLayout.tsx
+++ b/front/components/organisms/AdminLayout.tsx
@@ -12,11 +12,11 @@ import { SPNavbar } from '../molecule/SPNavbar'
 
 interface Props {
   title: string
-  header: string
+  header?: string
   children: JSX.Element
 }
 
-export const AdminLayout: React.FC<Props> = ({ title, header, children }) => {
+export const AdminLayout: React.FC<Props> = ({ title, header = '', children }) => {
   const { data } = useQueryOrganizations()
   const { push } = useRouter()
 

--- a/front/hooks/mutate/useMutateMembers.ts
+++ b/front/hooks/mutate/useMutateMembers.ts
@@ -22,5 +22,16 @@ export const useMutateMembers = () => {
     },
   )
 
-  return { createMembers }
+  const selectMembers = useMutation(async (id: string) => {
+    const { data, error } = await supabase
+      .from('members')
+      .select('member_id, profiles (username, avatar, is_admin)')
+      .eq('organization_id', id)
+
+    if (error) throw new Error(error.message)
+
+    return data
+  })
+
+  return { createMembers, selectMembers }
 }

--- a/front/pages/management/members/index.tsx
+++ b/front/pages/management/members/index.tsx
@@ -1,13 +1,57 @@
 //lib
 import { NextPage } from 'next'
+import { toast } from 'react-toastify'
+import { useEffect, useState } from 'react'
+
+//hooks
+import { useMutateMembers } from '../../../hooks/mutate/useMutateMembers'
+import { useQueryOrganizations } from '../../../hooks/query/useQueryOrganizations'
 
 //components
 import { AdminLayout } from '../../../components/organisms/AdminLayout'
+import { MemberList } from '../../../components/atom/MemberList'
+
+//types
+import { MemberLists } from '../../../types'
 
 const MembersPage: NextPage = () => {
+  const [members, setMembers] = useState<MemberLists[]>([])
+
+  const { selectMembers } = useMutateMembers()
+  const { data } = useQueryOrganizations()
+
+  useEffect(() => {
+    selectMembers
+      .mutateAsync(data!.id)
+      .then((data) => setMembers(data))
+      .catch(() => toast.error('予期せぬエラーが発生しました'))
+  }, [])
+
   return (
-    <AdminLayout title="メンバー一覧" header="メンバー一覧">
-      <div>メンバー一覧</div>
+    <AdminLayout title="メンバー">
+      <div className="w-full overflow-x-auto px-10 ">
+        <table className="table w-full">
+          <thead>
+            <tr>
+              <th>名前</th>
+              <th>役割</th>
+              <th>招待状況</th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((member, key) => {
+              return (
+                <MemberList
+                  key={key}
+                  username={member.profiles.username}
+                  avatar={member.profiles.avatar}
+                  is_admin={member.profiles.is_admin}
+                />
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
     </AdminLayout>
   )
 }

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -37,3 +37,12 @@ export interface ManagementContents {
   contentsName: string
   icon: JSX.Element
 }
+
+export interface MemberLists {
+  member_id: string
+  profiles: {
+    username: string
+    avatar: string
+    is_admin: boolean
+  }
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要

グループ内のメンバーの一覧ぺージを作成しました。
仮で招待状況の確認の一覧がありますが、今後追加する招待の状況を管理者が把握するためのカラムです。

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

# 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

# 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件

招待機能は作っていないため、擬似的にsupabaseの方でグループにユーザーを追加したところしっかり反映されていました。

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
